### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/beekhoury/beekhoury_output.py
+++ b/beekhoury/beekhoury_output.py
@@ -127,87 +127,87 @@ class beekhouryOutputPage(webapp.RequestHandler):
             <table border="1">
                 <tr>
                     <td>Egg Laying Rate Factor</td>
-                    <td>%s</td>
+                    <td>{0!s}</td>
                 </tr>
                 <tr>
                     <td>Alpha</td>
-                    <td>%s</td>
+                    <td>{1!s}</td>
                     <td></td>
                 </tr>
                 <tr>
                     <td>Theta</td>
-                    <td>%s</td>
+                    <td>{2!s}</td>
                 </tr>
                 <tr>
                     <td>Daily Laying Rate</td>
-                    <td>%s</td>
+                    <td>{3!s}</td>
                 </tr>
                 <tr>
                     <td>Mortality</td>
-                    <td>%s</td>
+                    <td>{4!s}</td>
                 </tr>
                  <tr>
                     <td>Forager Mortality</td>
-                    <td>%s</td>
+                    <td>{5!s}</td>
                 </tr>
                  <tr>
                     <td>Colony Size</td>
-                    <td>%s</td>
+                    <td>{6!s}</td>
                 </tr>
                  <tr>
                     <td>Number of Days</td>
-                    <td>%s</td>
+                    <td>{7!s}</td>
                 </tr>
             </table>
         </div>
-        """ % (w, alpha, theta, l, mo, deltam, no, t)
+        """.format(w, alpha, theta, l, mo, deltam, no, t)
         html = html + """
         <div class="out_">
             <H3>Outputs for the last day of the model run</H3>
             <table border="1">
                 <tr>
                     <td>Total mortality</td>
-                    <td>%.2f</td>
+                    <td>{0:.2f}</td>
                 </tr>
                 <tr>
                     <td>Forager bees</td>
-                    <td>%.0f</td>
+                    <td>{1:.0f}</td>
                 </tr>
                 <tr>
                     <td>Hive bees</td>
-                    <td>%.0f</td>
+                    <td>{2:.0f}</td>
                 </tr>
                 <tr>
                     <td>Total bee population</td>
-                    <td>%.0f</td>
+                    <td>{3:.0f}</td>
                 </tr>
                  <tr>
                     <td>Average age onset of foraging</td>
-                    <td>%.2f</td>
+                    <td>{4:.2f}</td>
                 </tr>
                  <tr>
                     <td>Forager lifespan</td>
-                    <td>%.2f</td>
+                    <td>{5:.2f}</td>
                 </tr>
             </table>
         </div>
-        """% (m, hive(t, no, l, w, alpha, theta, mo, deltam)[0][t-2], hive(t, no, l, w, alpha, theta, mo, deltam)[1][t-2], hive(t, no, l, w, alpha, theta, mo, deltam)[2][t-2], aaof_f(precruit, t), lifespan_f(precruit, t, m, deltam))
+        """.format(m, hive(t, no, l, w, alpha, theta, mo, deltam)[0][t-2], hive(t, no, l, w, alpha, theta, mo, deltam)[1][t-2], hive(t, no, l, w, alpha, theta, mo, deltam)[2][t-2], aaof_f(precruit, t), lifespan_f(precruit, t, m, deltam))
         html = html +  """
         <table width="400" border="1", style="display:none">
             <tr>
                 <td>hive_val_1</td>
-                <td id="hive_val_1">%s</td>
+                <td id="hive_val_1">{0!s}</td>
             </tr>
             <tr>
                 <td>hive_val_2</td>
-                <td id="hive_val_2">%s</td>
+                <td id="hive_val_2">{1!s}</td>
             </tr>
             <tr>
                 <td>hive_val_3</td>
-                <td id="hive_val_3">%s</td>
+                <td id="hive_val_3">{2!s}</td>
             </tr>                                                    
         </table>
-        """%(hive(t, no, l, w, alpha, theta, mo, deltam)[0],hive(t, no, l, w, alpha, theta, mo, deltam)[1],hive(t, no, l, w, alpha, theta, mo, deltam)[2])        
+        """.format(hive(t, no, l, w, alpha, theta, mo, deltam)[0], hive(t, no, l, w, alpha, theta, mo, deltam)[1], hive(t, no, l, w, alpha, theta, mo, deltam)[2])        
         html = html + template.render(templatepath + 'beekhoury-output-jqplot.html', {})         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/beepop/beepop_output.py
+++ b/beepop/beepop_output.py
@@ -306,86 +306,86 @@ class beepopOutputPage(webapp.RequestHandler):
             <table>
                 <tr>
                     <td>Initial colony size</td>
-                    <td>%s</td>
+                    <td>{0!s}</td>
                 </tr>
                 <tr>
                     <td>Sperm obtained</td>
-                    <td>%s</td>
+                    <td>{1!s}</td>
                 </tr>
                 <tr>
                     <td>Potential eggs laid</td>
-                    <td>%s</td>
+                    <td>{2!s}</td>
                 </tr>
                 <tr>
                     <td>Number of foraging days</td>
-                    <td>%s</td>
+                    <td>{3!s}</td>
                 </tr>
                  <tr>
                     <td>Brood cycles</td>
-                    <td>%s</td>
+                    <td>{4!s}</td>
                 </tr>
                  <tr>
                     <td>Days for eggs to develop into adult worker</td>
-                    <td>%s</td>
+                    <td>{5!s}</td>
                 </tr>
                  <tr>
                     <td>Days for eggs to develop into adult drones</td>
-                    <td>%s</td>
+                    <td>{6!s}</td>
                 </tr>
                 <tr>
                     <td>Days for inside worker bees to develop into foragers</td>
-                    <td>%s</td>
+                    <td>{7!s}</td>
                 </tr>
                 <tr>
                     <td>Number of foragers until death</td>
-                    <td>%s</td>
+                    <td>{8!s}</td>
                 </tr>
                 <tr>
                     <td>Percentage of eggs surviving to adults</td>
-                    <td>%s</td>
+                    <td>{9!s}</td>
                 </tr>
             </table>
         </div>
-        """ % (initial_colony_size, sperm_obtained, e_max, number_of_forages, brood_cycles, days_to_adult_worker, days_to_adult_drones, days_from_adult_to_forager, number_of_forages, egg_mortality)
+        """.format(initial_colony_size, sperm_obtained, e_max, number_of_forages, brood_cycles, days_to_adult_worker, days_to_adult_drones, days_from_adult_to_forager, number_of_forages, egg_mortality)
         html = html + """
         <div class="out_">
             <H3>Outputs for the last day of the model run</H3>
             <table>
                 <tr>
                     <td>Worker bees</td>
-                    <td>%.2f</td>
+                    <td>{0:.2f}</td>
                 </tr>
                 <tr>
                     <td>Forager bees</td>
-                    <td>%.2f</td>
+                    <td>{1:.2f}</td>
                 </tr>
                 <tr>
                     <td>Drones bees</td>
-                    <td>%.2f</td>
+                    <td>{2:.2f}</td>
                 </tr>
             </table>
         </div>
-        """ % (Et_f(winter_kill, kill_percent,swarm, swarm_date,adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[4], Et_f(winter_kill, kill_percent,swarm, swarm_date,adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[5], Et_f(winter_kill, kill_percent,swarm, swarm_date,adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[6])
+        """.format(Et_f(winter_kill, kill_percent,swarm, swarm_date,adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[4], Et_f(winter_kill, kill_percent,swarm, swarm_date,adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[5], Et_f(winter_kill, kill_percent,swarm, swarm_date,adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[6])
         html = html +  """
         <table width="400" border="1", style="display:none">
             <tr>
                 <td>hive_val_1</td>
-                <td id="Eggs_laid">%s</td>
+                <td id="Eggs_laid">{0!s}</td>
             </tr>
             <tr>
                 <td>hive_val_2</td>
-                <td id="Adult_workers">%s</td>
+                <td id="Adult_workers">{1!s}</td>
             </tr>
             <tr>
                 <td>hive_val_3</td>
-                <td id="Foragers">%s</td>
+                <td id="Foragers">{2!s}</td>
             </tr>
             <tr>
                 <td>hive_val_3</td>
-                <td id="Drones">%s</td>
+                <td id="Drones">{3!s}</td>
             </tr>                                                     
       </table>
-        """%(Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[0],Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[9],Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[8],Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[7])        
+        """.format(Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[0], Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[9], Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[8], Et_f(winter_kill, kill_percent,swarm, swarm_date, adult_brood_ratio, egg_mortality, e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[7])        
         html = html + template.render(templatepath + 'beepop-outputjqplot.html', {})         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/beepop/beepop_output_old.py
+++ b/beepop/beepop_output_old.py
@@ -291,60 +291,60 @@ class beepopOutputPage(webapp.RequestHandler):
         <tr><H3>User Inputs</H3></tr>
         <tr>
         <td>Initial colony size</td>
-        <td>%s</td>
+        <td>{0!s}</td>
         </tr>
         <tr>
         <td>Sperm obtained</td>
-        <td>%s</td>
+        <td>{1!s}</td>
         </tr>
         <tr>
         <td>Potential eggs laid</td>
-        <td>%s</td>
+        <td>{2!s}</td>
         </tr>
         <tr>
         <td>Number of foraging days</td>
-        <td>%s</td>
+        <td>{3!s}</td>
         </tr>
          <tr>
         <td>Brood cycles</td>
-        <td>%s</td>
+        <td>{4!s}</td>
         </tr>
          <tr>
         <td>Days for eggs to develop into adult worker</td>
-        <td>%s</td>
+        <td>{5!s}</td>
         </tr>
          <tr>
         <td>Days for eggs to develop into adult drones</td>
-        <td>%s</td>
+        <td>{6!s}</td>
         </tr>
         <tr>
         <td>Days for inside worker bees to develop into foragers</td>
-        <td>%s</td>
+        <td>{7!s}</td>
         </tr>
         <tr>
         <td>Number of foragers until death</td>
-        <td>%s</td>
+        <td>{8!s}</td>
         </tr>
         <tr>
         </table>
-        """ % (initial_colony_size, sperm_obtained, e_max, number_of_forages, brood_cycles, days_to_adult_worker, days_to_adult_drones, days_from_adult_to_forager, number_of_forages)
+        """.format(initial_colony_size, sperm_obtained, e_max, number_of_forages, brood_cycles, days_to_adult_worker, days_to_adult_drones, days_from_adult_to_forager, number_of_forages)
         html = html + """
         <table border="1">
         <tr><H3>Outputs for the last day of the model run</H3></tr>
         <tr>
         <td>Total mortality</td>
-        <td>%.2f</td>
+        <td>{0:.2f}</td>
         </tr>
         <tr>
         <td>Forager bees</td>
-        <td>%.2f</td>
+        <td>{1:.2f}</td>
         </tr>
         <tr>
         <td>Hive bees</td>
-        <td>%.2f</td>
+        <td>{2:.2f}</td>
         </tr>
         </table>
-        """ % (Et_f(e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[4], Et_f(e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[5], Et_f(e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[6])
+        """.format(Et_f(e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[4], Et_f(e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[5], Et_f(e_max, days_to_adult_drones, sperm_obtained, days_to_adult_worker, days_from_adult_to_forager, number_of_forages, initial_colony_size)[6])
 #        html = html +  """<table width="400" border="1", style="display:none">
 #                          <tr>
 #                            <td>hive_val_1</td>

--- a/exponential/exponential_output.py
+++ b/exponential/exponential_output.py
@@ -53,27 +53,27 @@ class exponentialOutputPage(webapp.RequestHandler):
                           <tr>
                             <td>Initial amount of individuals</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{0!s}</td>
                           </tr>                                                  
                           <tr>
                             <td>Initial growth rate</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{1!s}</td>
                           </tr>                           
                           <tr>
                             <td>Number of time intervals</td>
                             <td>time unit</td>                            
-                            <td>%s</td>
+                            <td>{2!s}</td>
                           </tr>                                                                                                                
                         </table>
-                        <p>&nbsp;</p>"""%(N_o, rho, T)
+                        <p>&nbsp;</p>""".format(N_o, rho, T)
 
         html = html +  """<table width="400" border="0" style="display: none">
                           <tr>
                             <td>X</td>
-                            <td id="x_indi_val">%s</td>
+                            <td id="x_indi_val">{0!s}</td>
                           </tr>
-                          </table>"""%((x_out))
+                          </table>""".format(((x_out)))
         html = html +   """<div id="chart1" style="margin-top:20px; margin-left:20px; width:650px; height:400px;"></div>"""
 
         html = html + template.render(templatepath + '04uberoutput_end.html', {})

--- a/fellerarley/fellerarley_output.py
+++ b/fellerarley/fellerarley_output.py
@@ -79,41 +79,41 @@ class fellerarleyOutputPage(webapp.RequestHandler):
                           <tr>
                             <td>Initial amount of individuals</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{0!s}</td>
                           </tr>                          
                           <tr>
                             <td>Probability of birth in a time step</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{1!s}</td>
                           </tr>
                           <tr>
                             <td>Probability of death in a time step</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{2!s}</td>
                           </tr>
                          <tr>
                             <td>Number of time intervals</td>
                             <td>time unit</td>                            
-                            <td>%s</td>
+                            <td>{3!s}</td>
                           </tr>
                           <tr>
                             <td>Number of iterations</td>
                             <td>&nbsp</td>                            
-                            <td id="ita">%s</td>
+                            <td id="ita">{4!s}</td>
                           </tr>                                                                                                                                                                                                                     
                         </table>
-                        <p>&nbsp;</p>"""%(N_o, rho, beta, T, Ite)
+                        <p>&nbsp;</p>""".format(N_o, rho, beta, T, Ite)
 
         html = html +  """<table width="400" border="1" style="display: none">
                           <tr >
                             <td>X</td>
-                            <td id="x">%s</td>
+                            <td id="x">{0!s}</td>
                           </tr>
                           <tr >
                             <td>x_mu</td>
-                            <td id="x_mu">%s</td>
+                            <td id="x_mu">{1!s}</td>
                           </tr>                          
-                          </table>"""%(x,x_mu)
+                          </table>""".format(x, x_mu)
         html = html + template.render(templatepath + 'fellerarley-output-jqplot.html', {})                         
         html = html + template.render(templatepath + '04uberoutput_end.html', {'sub_title': ''})
         html = html + template.render(templatepath + 'export.html', {})

--- a/foxsurplus/foxsurplus_output.py
+++ b/foxsurplus/foxsurplus_output.py
@@ -60,42 +60,42 @@ class foxsurplusOutputPage(webapp.RequestHandler):
                           <tr>
                             <td>Initial amount of individuals</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{0!s}</td>
                           </tr>                          
                           <tr>
                             <td>Carrying capacity</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{1!s}</td>
                           </tr>                          
                           <tr>
                             <td>Initial growth rate</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{2!s}</td>
                           </tr>
                           <tr>
                             <td>Catchability</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{3!s}</td>
                           </tr>
                           <tr>
                             <td>Effort</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{4!s}</td>
                           </tr>                                                    
                           <tr>
                             <td>Number of time intervals</td>
                             <td>time unit</td>                            
-                            <td>%s</td>
+                            <td>{5!s}</td>
                           </tr>                                                                                                                
                         </table>
-                        <p>&nbsp;</p>"""%(N_o, K, rho, q, E, T)
+                        <p>&nbsp;</p>""".format(N_o, K, rho, q, E, T)
 
         html = html +  """<table width="400" border="0" style="display: none">
                           <tr>
                             <td>X</td>
-                            <td id="x_indi_val">%s</td>
+                            <td id="x_indi_val">{0!s}</td>
                           </tr>
-                          </table>"""%((x_out))
+                          </table>""".format(((x_out)))
         html = html + template.render(templatepath + 'foxsurplus-output-jqplot.html', {})                         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/gompertz/gompertz_output.py
+++ b/gompertz/gompertz_output.py
@@ -55,32 +55,32 @@ class gompertzOutputPage(webapp.RequestHandler):
                           <tr>
                             <td>Initial amount of individuals</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{0!s}</td>
                           </tr>                          
                           <tr>
                             <td>Carrying capacity</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{1!s}</td>
                           </tr>                          
                           <tr>
                             <td>Initial growth rate</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{2!s}</td>
                           </tr>                        
                           <tr>
                             <td>Number of time intervals</td>
                             <td>time unit</td>                            
-                            <td>%s</td>
+                            <td>{3!s}</td>
                           </tr>                                                                                                                
                         </table>
-                        <p>&nbsp;</p>"""%(N_o, K, rho, T)
+                        <p>&nbsp;</p>""".format(N_o, K, rho, T)
 
         html = html +  """<table width="400" border="0" style="display: none">
                           <tr>
                             <td>X</td>
-                            <td id="x_indi_val">%s</td>
+                            <td id="x_indi_val">{0!s}</td>
                           </tr>
-                          </table>"""%((x_out))
+                          </table>""".format(((x_out)))
         html = html + template.render(templatepath + 'gompertz-output-jqplot.html', {})                         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/leslie/leslie_output.py
+++ b/leslie/leslie_output.py
@@ -60,25 +60,25 @@ class leslieOutputPage(webapp.RequestHandler):
                           <tr>
                             <td><div align="center">Simulation duration</div></td>
                             <td><div align="center">time unit</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{0!s}</div></td>
                           </tr>
                           <tr>
                             <td><div align="center">Modeled stages</div></td>
                             <td><div align="center">&nbsp</div></td>                            
-                            <td id="MS"><div align="center">%s</div></td>
+                            <td id="MS"><div align="center">{1!s}</div></td>
                           </tr>
                           <tr style="display:none">
                             <td><div align="center">Leslie Matrix</div></td>
                             <td><div align="center">&nbsp</div></td>
-                            <td id="LM"><div align="center">%s</div></td>
+                            <td id="LM"><div align="center">{2!s}</div></td>
                           </tr>
                           <tr style="display:none">
                             <td><div align="center">Initial numbers</div></td>
                             <td><div align="center">&nbsp</div></td>
-                            <td id="IN"><div align="center">%s</div></td>
+                            <td id="IN"><div align="center">{3!s}</div></td>
                           </tr>                                                                                                                                                                                                              
                         </table>
-                        <p>&nbsp;</p>"""%(T, S, l_m.tolist(), n_o.tolist())
+                        <p>&nbsp;</p>""".format(T, S, l_m.tolist(), n_o.tolist())
                         
         html = html + """<table class="lm out_" border="1">"""
                                             
@@ -88,10 +88,10 @@ class leslieOutputPage(webapp.RequestHandler):
         html = html +  """<table width="400" border="1" style="display: none">
                           <tr>
                             <td>X</td>
-                            <td id="final">%s</td>
+                            <td id="final">{0!s}</td>
                           </tr>
                        
-                          </table>"""%(x)
+                          </table>""".format((x))
         html = html + template.render(templatepath + 'leslie-output-jqplot.html', {})                         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/leslie_probit/leslie_probit_output.py
+++ b/leslie_probit/leslie_probit_output.py
@@ -86,21 +86,21 @@ class leslie_probit_OutputPage(webapp.RequestHandler):
         html = html +  """<table width="400" border="1" style="display:none">
                           <tr>
                             <td>number of class</td>
-                            <td id="n_o_c">%s</td>
+                            <td id="n_o_c">{0!s}</td>
                           </tr>
                           <tr>
                             <td>final population</td>
-                            <td id="final">%s</td>
+                            <td id="final">{1!s}</td>
                           </tr>                          
                           <tr>
                             <td>final population no impact</td>
-                            <td id="final_no">%s</td>
+                            <td id="final_no">{2!s}</td>
                           </tr>                          
                           <tr>
                             <td>concentrations</td>
-                            <td id="conc">%s</td>
+                            <td id="conc">{3!s}</td>
                           </tr>                          
-                          </table>"""%(leslie_probit_obj.s, leslie_probit_obj.out[4], leslie_probit_obj.out_no, leslie_probit_obj.conc_out)
+                          </table>""".format(leslie_probit_obj.s, leslie_probit_obj.out[4], leslie_probit_obj.out_no, leslie_probit_obj.conc_out)
         html = html + template.render(templatepath + 'lesliedr_probit_jqplot.html', {})                         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/leslie_probit/leslie_probit_tables.py
+++ b/leslie_probit/leslie_probit_tables.py
@@ -72,9 +72,9 @@ def gett1data(leslie_probit_obj):
 
 def gett2data(index, rate, day):
     data = { 
-        "App": ['%s' %index,  ],
+        "App": ['{0!s}'.format(index),  ],
         "Rate": [rate,],
-        "Day of Application": ['%s' %day,],
+        "Day of Application": ['{0!s}'.format(day),],
     }
     return data
 
@@ -88,7 +88,7 @@ def gett3data(leslie_probit_obj):
 
 def gett4data(index, n_o):
     data = { 
-        "Class": ['%s' %index,  ],
+        "Class": ['{0!s}'.format(index),  ],
         "Initial Population": [n_o[0],],
     }
     return data
@@ -150,9 +150,9 @@ def table_1(leslie_probit_obj):
 def table_2(leslie_probit_obj):
         # #pre-table 2
         html = """
-            <H4 class="out_2 collapsible" id="section2"><span></span>Chemical Application (n=%s)</H4>
+            <H4 class="out_2 collapsible" id="section2"><span></span>Chemical Application (n={0!s})</H4>
                 <div class="out_ container_output">
-        """ %(leslie_probit_obj.n_a)
+        """.format((leslie_probit_obj.n_a))
         #table 2
         t2data_all=[]
         for i in range(int(leslie_probit_obj.n_a)):

--- a/lesliedr/lesliedr_output.py
+++ b/lesliedr/lesliedr_output.py
@@ -102,60 +102,60 @@ class lesliedrOutputPage(webapp.RequestHandler):
                           <tr>
                             <td><div align="center">Animal name</div></td>
                             <td><div align="center">&nbsp</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{0!s}</div></td>
                           </tr>
                           <tr>
                             <td><div align="center">Chemical name</div></td>
                             <td><div align="center">&nbsp</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{1!s}</div></td>
                           </tr>
                           <tr>
                             <td><div align="center">Chemical half life</div></td>
                             <td><div align="center">days</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{2!s}</div></td>
                           </tr>
                           <tr>
                             <td><div align="center">Initial concentration</div></td>
                             <td><div align="center">&#956;g/l</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{3!s}</div></td>
                           </tr>                                                         
                           <tr>
                             <td><div align="center">Simulation duration</div></td>
                             <td><div align="center">time unit</div></td>                            
-                            <td id="sd"><div align="center">%s</div></td>
+                            <td id="sd"><div align="center">{4!s}</div></td>
                           </tr>
                           <tr>
                             <td><div align="center">Logistic model parameter (&#945;)</div></td>
                             <td><div align="center">&nbsp</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{5!s}</div></td>
                           </tr>
                           <tr>
                             <td><div align="center">Logistic model parameter (&#946;)</div></td>
                             <td><div align="center">&nbsp</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{6!s}</div></td>
                           </tr>
                           <tr>
                             <td><div align="center">Intensity of the density dependence (&#947;)</div></td>
                             <td><div align="center">&nbsp</div></td>                            
-                            <td><div align="center">%s</div></td>
+                            <td><div align="center">{7!s}</div></td>
                           </tr>                                    
                           <tr>
                             <td><div align="center">Number of age class</div></td>
                             <td><div align="center">&nbsp</div></td>                            
-                            <td id="MS"><div align="center">%s</div></td>
+                            <td id="MS"><div align="center">{8!s}</div></td>
                           </tr>
                           <tr style="display:none">
                             <td><div align="center">Leslie Matrix</div></td>
                             <td><div align="center">&nbsp</div></td>
-                            <td id="LM"><div align="center">%s</div></td>
+                            <td id="LM"><div align="center">{9!s}</div></td>
                           </tr>
                           <tr style="display:none">
                             <td><div align="center">Initial numbers</div></td>
                             <td><div align="center">&nbsp</div></td>
-                            <td id="IN"><div align="center">%s</div></td>
+                            <td id="IN"><div align="center">{10!s}</div></td>
                           </tr>                                                                                                                                                                                                              
                         </table>
-                        <p>&nbsp;</p>"""%(a_n, c_n, HL, Con, T, a, b, c, S, l_m.tolist(), n_o.tolist())
+                        <p>&nbsp;</p>""".format(a_n, c_n, HL, Con, T, a, b, c, S, l_m.tolist(), n_o.tolist())
                         
         html = html + """<table class="lm out_" border="1">"""
                                                                                         
@@ -164,17 +164,17 @@ class lesliedrOutputPage(webapp.RequestHandler):
         html = html +  """<table width="400" border="1" style="display:none">
                           <tr>
                             <td>X</td>
-                            <td id="final">%s</td>
+                            <td id="final">{0!s}</td>
                           </tr>
                           <tr>
                             <td>X_f</td>
-                            <td id="final_f">%s</td>
+                            <td id="final_f">{1!s}</td>
                           </tr>                          
                           <tr>
                             <td>X_f_no</td>
-                            <td id="final_f_no">%s</td>
+                            <td id="final_f_no">{2!s}</td>
                           </tr>                          
-                          </table>"""%(x, x_f, x_no_f)
+                          </table>""".format(x, x_f, x_no_f)
         html = html + template.render(templatepath + 'lesliedr-output-jqplot.html', {})
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/logistic/logistic_output.py
+++ b/logistic/logistic_output.py
@@ -56,32 +56,32 @@ class logisticOutputPage(webapp.RequestHandler):
                           <tr>
                             <td>Initial amount of individuals</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{0!s}</td>
                           </tr>                          
                           <tr>
                             <td>Carrying capacity</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{1!s}</td>
                           </tr>                          
                           <tr>
                             <td>Initial growth rate</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{2!s}</td>
                           </tr>
                           <tr>
                             <td>Number of time intervals</td>
                             <td>time unit</td>                            
-                            <td>%s</td>
+                            <td>{3!s}</td>
                           </tr>                                                                                                                
                         </table>
-                        <p>&nbsp;</p>"""%(x_ini, M, rho, N)
+                        <p>&nbsp;</p>""".format(x_ini, M, rho, N)
 
         html = html +  """<table width="400" border="0" style="display: none;">
                           <tr>
                             <td>X</td>
-                            <td id="x_indi_val">%s</td>
+                            <td id="x_indi_val">{0!s}</td>
                           </tr>
-                          </table>"""%((x_out))
+                          </table>""".format(((x_out)))
         html = html + template.render(templatepath + 'logistic-output-jqplot.html', {})
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/loons/loons_output.py
+++ b/loons/loons_output.py
@@ -52,9 +52,9 @@ class loons_OutputPage(webapp.RequestHandler):
                           </tr>
                           <tr>
                             <td>final population</td>
-                            <td id="final">%s</td>
+                            <td id="final">{0!s}</td>
                           </tr>                          
-                          </table>"""%(loons_obj.leslie_out)
+                          </table>""".format((loons_obj.leslie_out))
         html = html + template.render(templatepath + 'loons_jqplot.html', {})                         
 
         html = html + template.render(templatepath + '04uberoutput_end.html', {})

--- a/loons/loons_tables.py
+++ b/loons/loons_tables.py
@@ -78,10 +78,10 @@ def gett1data(loons_obj):
 def gett3adata(loons_obj):
     data = { 
         "Class": ["Juvenile Year 1", "Juvenile Year 2", "Juvenile Year 3", "Adult"],
-        "Juvenile Year 1": ['%.2f' %loons_obj.l_m[0,0], '%.2f' %loons_obj.l_m[1,0], '%.2f' %loons_obj.l_m[2,0], '%.2f' %loons_obj.l_m[3,0]],
-        "Juvenile Year 2": ['%.2f' %loons_obj.l_m[0,1], '%.2f' %loons_obj.l_m[1,1], '%.2f' %loons_obj.l_m[2,1], '%.2f' %loons_obj.l_m[3,1]],
-        "Juvenile Year 3": ['%.2f' %loons_obj.l_m[0,2], '%.2f' %loons_obj.l_m[1,2], '%.2f' %loons_obj.l_m[2,2], '%.2f' %loons_obj.l_m[3,2]],
-        "Adult": ['%.2f' %loons_obj.l_m[0,3], '%.2f' %loons_obj.l_m[1,3], '%.2f' %loons_obj.l_m[2,3], '%.2f' %loons_obj.l_m[3,3]],
+        "Juvenile Year 1": ['{0:.2f}'.format(loons_obj.l_m[0,0]), '{0:.2f}'.format(loons_obj.l_m[1,0]), '{0:.2f}'.format(loons_obj.l_m[2,0]), '{0:.2f}'.format(loons_obj.l_m[3,0])],
+        "Juvenile Year 2": ['{0:.2f}'.format(loons_obj.l_m[0,1]), '{0:.2f}'.format(loons_obj.l_m[1,1]), '{0:.2f}'.format(loons_obj.l_m[2,1]), '{0:.2f}'.format(loons_obj.l_m[3,1])],
+        "Juvenile Year 3": ['{0:.2f}'.format(loons_obj.l_m[0,2]), '{0:.2f}'.format(loons_obj.l_m[1,2]), '{0:.2f}'.format(loons_obj.l_m[2,2]), '{0:.2f}'.format(loons_obj.l_m[3,2])],
+        "Adult": ['{0:.2f}'.format(loons_obj.l_m[0,3]), '{0:.2f}'.format(loons_obj.l_m[1,3]), '{0:.2f}'.format(loons_obj.l_m[2,3]), '{0:.2f}'.format(loons_obj.l_m[3,3])],
     }
     return data
 
@@ -89,10 +89,10 @@ def gett4data(loons_obj):
     data = { 
         "Parameter": [mark_safe('Pairing propensity for age &ge; 3'), "Chicks raised to mid-Aug per paired female", mark_safe('Annual survival for age < 3'), "Juvenile Maturation rate",
                       mark_safe('Annual survival for age &ge; 3'), "Per capita fecundity", "Probility of a juvenile growing into an adult", "Probility of a juvenile remain in the class"],
-        "Sensitivity": ['%.4f' %loons_obj.sen_b, '%.4f' % loons_obj.sen_m, '%.4f' % loons_obj.sen_sj, '%.4f' % loons_obj.sen_rj,  
-                        '%.4f' %loons_obj.sen_pa, '%.4f' % loons_obj.sen_fa, '%.4f' % loons_obj.sen_gj, '%.4f' % loons_obj.sen_pj],
-        "Elasticity": ['%.4f' %loons_obj.ela_b, '%.4f' % loons_obj.ela_m, '%.4f' % loons_obj.ela_sj, '%.4f' % loons_obj.ela_rj,  
-                       '%.4f' %loons_obj.ela_pa, '%.4f' % loons_obj.ela_fa, '%.4f' % loons_obj.ela_gj, '%.4f' % loons_obj.ela_pj],
+        "Sensitivity": ['{0:.4f}'.format(loons_obj.sen_b), '{0:.4f}'.format(loons_obj.sen_m), '{0:.4f}'.format(loons_obj.sen_sj), '{0:.4f}'.format(loons_obj.sen_rj),  
+                        '{0:.4f}'.format(loons_obj.sen_pa), '{0:.4f}'.format(loons_obj.sen_fa), '{0:.4f}'.format(loons_obj.sen_gj), '{0:.4f}'.format(loons_obj.sen_pj)],
+        "Elasticity": ['{0:.4f}'.format(loons_obj.ela_b), '{0:.4f}'.format(loons_obj.ela_m), '{0:.4f}'.format(loons_obj.ela_sj), '{0:.4f}'.format(loons_obj.ela_rj),  
+                       '{0:.4f}'.format(loons_obj.ela_pa), '{0:.4f}'.format(loons_obj.ela_fa), '{0:.4f}'.format(loons_obj.ela_gj), '{0:.4f}'.format(loons_obj.ela_pj)],
     }
     return data
 
@@ -211,7 +211,7 @@ def table_4(loons_obj):
 
 def table_5(loons_obj):
         html = """
-            <H4 class="out_4 collapsible" id="section4"><span></span>Population growth rate confidence interval (Iteration = %s)</H4>
+            <H4 class="out_4 collapsible" id="section4"><span></span>Population growth rate confidence interval (Iteration = {0!s})</H4>
                 <div class="out_ container_output">
                     <table class="out_">
                         <tr>
@@ -221,10 +221,10 @@ def table_5(loons_obj):
                         </tr>
                         <tr>
                             <td>Population growth rate (&lambda;)</td>
-                            <td>%.4f</td>
-                            <td>%.4f</td>
+                            <td>{1:.4f}</td>
+                            <td>{2:.4f}</td>
                         </tr>
                     </table>
                 </div>
-        """ % (10000, loons_obj.lamda_ci_out_025, loons_obj.lamda_ci_out_975)
+        """.format(10000, loons_obj.lamda_ci_out_025, loons_obj.lamda_ci_out_975)
         return html

--- a/maxsus/maxsus_output.py
+++ b/maxsus/maxsus_output.py
@@ -69,26 +69,26 @@ class maxsusOutputPage(webapp.RequestHandler):
                           <tr>
                             <td>Carrying capacity</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{0!s}</td>
                           </tr>                          
                           <tr>
                             <td>Initial growth rate</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{1!s}</td>
                           </tr>                                                                                                                                                               
                         </table>
-                        <p>&nbsp;</p>"""%(K, rho)
+                        <p>&nbsp;</p>""".format(K, rho)
 
         html = html +  """<table width="400" border="1" style="display: none">
                           <tr >
                             <td>X</td>
-                            <td id="x_out_val">%s</td>
+                            <td id="x_out_val">{0!s}</td>
                           </tr>
                           <tr >
                             <td>H</td>
-                            <td id="H_val">%s</td>
+                            <td id="H_val">{1!s}</td>
                           </tr>                          
-                          </table>"""%(x_out,H)
+                          </table>""".format(x_out, H)
         html = html + template.render(templatepath + 'maxsus-output-jqplot.html', {})                         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})

--- a/yulefurry/yulefurry_output.py
+++ b/yulefurry/yulefurry_output.py
@@ -76,36 +76,36 @@ class yulefurryOutputPage(webapp.RequestHandler):
                           <tr>
                             <td>Initial amount of individuals</td>
                             <td>&nbsp</td>                            
-                            <td>%s</td>
+                            <td>{0!s}</td>
                           </tr>                          
                           <tr>
                             <td>Initial growth rate</td>
                             <td>&#37;</td>                            
-                            <td>%s</td>
+                            <td>{1!s}</td>
                           </tr>
                           <tr>
                             <td>Number of time intervals</td>
                             <td>time unit</td>                            
-                            <td>%s</td>
+                            <td>{2!s}</td>
                           </tr>
                           <tr>
                             <td>Number of iterations</td>
                             <td>&nbsp</td>                            
-                            <td id="ita">%s</td>
+                            <td id="ita">{3!s}</td>
                           </tr>                                                                                                                                                                                                                  
                         </table>
-                        <p>&nbsp;</p>"""%(N_o, rho, T, Ite)
+                        <p>&nbsp;</p>""".format(N_o, rho, T, Ite)
 
         html = html +  """<table width="400" border="1" style="display: none">
                           <tr>
                             <td>X</td>
-                            <td id="x">%s</td>
+                            <td id="x">{0!s}</td>
                           </tr>
                           <tr >
                             <td>x_mu</td>
-                            <td id="x_mu">%s</td>
+                            <td id="x_mu">{1!s}</td>
                           </tr>                          
-                          </table>"""%(x,x_mu)
+                          </table>""".format(x, x_mu)
         html = html + template.render(templatepath + 'yulefurry-output-jqplot.html', {})                         
         html = html + template.render(templatepath + '04uberoutput_end.html', {})
         html = html + template.render(templatepath + 'export.html', {})


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:quanted:pop_app?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:quanted:pop_app?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)